### PR TITLE
Fixing Restrict Corpus

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -34,7 +34,7 @@ restrictCorpus <- function(counts,
                            verbose=TRUE) {
   
   ## remove genes that are present in more than X% of pixels
-  vi <- rowSums(as.matrix(counts) > 0) >= ncol(counts)*removeAbove
+  vi <- rowSums(as.matrix(counts) > 0) > ncol(counts)*removeAbove
   if(verbose) {
     message(paste0('Removing ', sum(vi), ' genes present in ',
                    removeAbove*100, '% or more of pixels...'))
@@ -45,7 +45,7 @@ restrictCorpus <- function(counts,
   }
   
   ## remove genes that are present in less than X% of pixels
-  vi <- rowSums(as.matrix(counts) > 0) <= ncol(counts)*removeBelow
+  vi <- rowSums(as.matrix(counts) > 0) < ncol(counts)*removeBelow
   if(verbose) {
     message(paste0('Removing ', sum(vi), ' genes present in ',
                    removeBelow*100, '% or less of pixels...'))


### PR DESCRIPTION
Hi Jean,

After further investigation, I found the cause of this code failing with Nanostring DSP data.

The issue arises because this type of data has a high proportion of important genes present in all cells (or spots), and a relatively low number of spots (around 59). 

In my Python code, I use `scanpy` with the following filter:
```python
sc.pp.filter_genes(adata_spatial, max_cells=int(removeAbove * len(adata_spatial)), inplace=True)
```
This approach does not discard genes if they meet the `removeAbove` threshold.

In your function, however, the "greater than or equal" condition discards genes in this edge case. To address this, I modified the function so that `removeAbove=1` and `removeBelow=0` will not remove any genes

Let me know if you agree with this approach. If you’re okay with it, feel free to merge!

Best,
Aly