### PR TITLE
Add color palette option to vizTopic function

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -208,6 +208,7 @@ vizTopic <- function(theta, pos, topic,
                      alpha = 1,
                      low = "white",
                      high = "red",
+                     palette = NULL,
                      plotTitle = NA,
                      showLegend = TRUE) {
   
@@ -269,10 +270,14 @@ vizTopic <- function(theta, pos, topic,
       legend.title = ggplot2::element_text(size = 12, colour = "black")
     ) +
     
-    ggplot2::scale_fill_gradientn(limits = c(0, 1.0),
-                                  breaks = c(0, 0.2, 0.4, 0.6, 0.8, 1.0),
-                                  colors=(grDevices::colorRampPalette(c(low, high)))(n = 209)
-    ) +
+    if (!is.null(palette)) {
+     ggplot2::scale_fill_gradientn(colours = palette,
+                                             limits = c(0, 1.0))
+    } else {
+      ggplot2::scale_fill_gradientn(limits = c(0, 1.0),
+                                      breaks = seq(0, 1, 0.2),
+                                      colors = grDevices::colorRampPalette(c(low, high))(209))
+    } +
     
     ggplot2::guides(fill = ggplot2::guide_colorbar(title = "Proportion",
                                                    title.position = "left",

--- a/R/plot.R
+++ b/R/plot.R
@@ -181,6 +181,8 @@ vizAllTopics <- function(theta, pos,
 #' @param alpha alpha value of colored pixels (default: 1)
 #' @param low sets the color for the low end of the topic proportion color scale (default: "white")
 #' @param high sets the color the the high end of the topic proportion color scale (default: "red")
+#' @param palette optional vector of colors for custom color scales (e.g., `viridis::viridis(200)`). 
+#'     If NULL, a gradient from `low` to `high` is used.
 #' @param plotTitle option to add a title to the plot (character)
 #' @param showLegend Boolean to show the plot legend
 #' 
@@ -196,8 +198,14 @@ vizAllTopics <- function(theta, pos,
 #' optLDA <- optimalModel(models = ldas, opt = 3)
 #' results <- getBetaTheta(optLDA, perc.filt = 0.05, betaScale = 1000)
 #' deconProp <- results$theta
+#' 
+#' # Using the default low/high color scheme:
 #' vizTopic(theta = deconProp, pos = pos, topic = "3", plotTitle = "X3",
 #'     size = 5, stroke = 1, alpha = 0.5, low = "white", high = "red")
+#'
+#' # Using a custom palette (e.g., viridis colors):
+#' vizTopic(theta = deconProp, pos = pos, topic = "3", plotTitle = "X3",
+#'     size = 5, stroke = 1, alpha = 0.5, palette = viridis::viridis(200))
 #' 
 #' @export
 vizTopic <- function(theta, pos, topic,

--- a/R/plot.R
+++ b/R/plot.R
@@ -278,21 +278,12 @@ vizTopic <- function(theta, pos, topic,
       legend.title = ggplot2::element_text(size = 12, colour = "black")
     ) +
     
-    if (!is.null(palette)) {
-     ggplot2::scale_fill_gradientn(colours = palette,
-                                             limits = c(0, 1.0))
-    } else {
-      ggplot2::scale_fill_gradientn(limits = c(0, 1.0),
-                                      breaks = seq(0, 1, 0.2),
-                                      colors = grDevices::colorRampPalette(c(low, high))(209))
-    } +
-    
     ggplot2::guides(fill = ggplot2::guide_colorbar(title = "Proportion",
                                                    title.position = "left",
                                                    title.hjust = 0.5,
                                                    ticks.colour = "black",
                                                    ticks.linewidth = 2,
-                                                   frame.colour= "black",
+                                                   frame.colour = "black",
                                                    frame.linewidth = 2,
                                                    label.hjust = 0,
                                                    title.theme = ggplot2::element_text(angle = 90)
@@ -304,6 +295,17 @@ vizTopic <- function(theta, pos, topic,
   
   if (!is.na(plotTitle)) {
     p <- p + ggplot2::ggtitle(plotTitle)
+  }
+  
+  if (!is.null(palette)) {
+    p <- p +  ggplot2::scale_fill_gradientn(limits = c(0, 1.0),
+                                            breaks = c(0, 0.2, 0.4, 0.6, 0.8, 1.0),
+                                            colors = palette)
+  } else {
+    p <- p + ggplot2::scale_fill_gradientn(limits = c(0, 1.0),
+                                           breaks = c(0, 0.2, 0.4, 0.6, 0.8, 1.0),
+                                           colors = (grDevices::colorRampPalette(c(low, high)))(n = 209)
+    )
   }
   
   p <- p + ggplot2::coord_equal()

--- a/man/vizTopic.Rd
+++ b/man/vizTopic.Rd
@@ -15,6 +15,7 @@ vizTopic(
   alpha = 1,
   low = "white",
   high = "red",
+  palette = NULL,
   plotTitle = NA,
   showLegend = TRUE
 )
@@ -43,6 +44,9 @@ Ex: c("0", "1", "0", ...)}
 
 \item{high}{sets the color the the high end of the topic proportion color scale (default: "red")}
 
+\item{palette}{optional vector of colors for custom color scales (e.g., \code{viridis::viridis(200)}).
+If NULL, a gradient from \code{low} to \code{high} is used.}
+
 \item{plotTitle}{option to add a title to the plot (character)}
 
 \item{showLegend}{Boolean to show the plot legend}
@@ -63,7 +67,13 @@ ldas <- fitLDA(t(as.matrix(corpus)), Ks = 3)
 optLDA <- optimalModel(models = ldas, opt = 3)
 results <- getBetaTheta(optLDA, perc.filt = 0.05, betaScale = 1000)
 deconProp <- results$theta
+
+# Using the default low/high color scheme:
 vizTopic(theta = deconProp, pos = pos, topic = "3", plotTitle = "X3",
     size = 5, stroke = 1, alpha = 0.5, low = "white", high = "red")
+
+# Using a custom palette (e.g., viridis colors):
+vizTopic(theta = deconProp, pos = pos, topic = "3", plotTitle = "X3",
+    size = 5, stroke = 1, alpha = 0.5, palette = viridis::viridis(200))
 
 }


### PR DESCRIPTION
This fork adds an optional `palette` argument to `vizTopic`, allowing users to define custom color scales instead of using the default gradient from `low` to `high`. 

- Added `palette` parameter to allow for custom color scales.
- Ensured backward compatibility by defaulting to `low` and `high` colors.
- Updated documentation (`roxygen2`).
- Passed all existing tests.

![Screenshot from 2025-02-28 16-20-14](https://github.com/user-attachments/assets/d79b4a71-d4b4-4d1b-9403-94df6d787fcf)